### PR TITLE
Dev

### DIFF
--- a/lib/src/convert.dart
+++ b/lib/src/convert.dart
@@ -2,7 +2,6 @@ library reflective.convert;
 
 import 'dart:convert';
 import 'package:reflective/src/core.dart';
-import 'package:reflective/src/util.dart';
 
 typedef dynamic Transformation(dynamic object);
 
@@ -131,8 +130,8 @@ class JsonToObject extends ConverterBase<Json, Object> {
   _convert(object, TypeReflection targetReflection) {
     if (object is Map) {
       if (targetReflection.sameOrSuper(Map)) {
-        TypeReflection keyType = targetReflection.arguments[0];
-        TypeReflection valueType = targetReflection.arguments[1];
+        TypeReflection keyType = targetReflection.genericArguments[0].value;
+        TypeReflection valueType = targetReflection.genericArguments[1].value;
         Map map = {};
         object.keys.forEach((k) {
           var newKey = keyType.sameOrSuper(k) ? k : keyType.construct(args: [k]);
@@ -149,7 +148,7 @@ class JsonToObject extends ConverterBase<Json, Object> {
         return instance;
       }
     } else if (object is Iterable) {
-      TypeReflection itemType = targetReflection.arguments[0];
+      TypeReflection itemType = targetReflection.genericArguments[0].value;
       return new List.from(object.map((i) => _convert(i, itemType)));
     } else if (targetReflection.sameOrSuper(DateTime)) {
       return DateTime.parse(object);

--- a/lib/src/core/field_reflection.dart
+++ b/lib/src/core/field_reflection.dart
@@ -1,6 +1,8 @@
 part of reflective.core;
 
 abstract class FieldReflection {
+  bool get isGeneric;
+
   bool has(Type metadata);
 
   List metadata(Type metadata);
@@ -34,6 +36,8 @@ class SimpleFieldReflection extends AbstractReflection<VariableMirror> with Fiel
 
   String toString() => name;
 
+  bool get isGeneric => _mirror.type is TypeVariableMirror;
+
   bool operator ==(o) =>
       o is FieldReflection && fullName == o.fullName && _symbol == o._symbol;
 }
@@ -63,4 +67,6 @@ class TransitiveFieldReflection implements FieldReflection {
   String get fullName => _source.fullName + '.' + _target.name;
 
   bool get isPrivate => _target.isPrivate;
+
+  bool get isGeneric => false;
 }

--- a/lib/src/core/library_reflection.dart
+++ b/lib/src/core/library_reflection.dart
@@ -2,36 +2,38 @@ part of reflective.core;
 
 LibraryReflection library(String libraryName) => new LibraryReflection(libraryName);
 
-class LibraryReflection
-{
-	LibraryMirror _library;
-	List<TypeReflection> _types;
+class LibraryReflection {
+  LibraryMirror _library;
+  List<TypeReflection> _types;
 
-	LibraryReflection.fromSymbol(Symbol libraryName)
-	{
-		_library = currentMirrorSystem().findLibrary(libraryName);
-		_loadTypes();
-	}
+  LibraryReflection.fromSymbol(Symbol libraryName) {
+    _library = currentMirrorSystem().findLibrary(libraryName);
+    _loadTypes();
+  }
 
-	LibraryReflection(String libraryName) {
-		if (libraryName.isEmpty) {
-			_library = currentMirrorSystem().isolate.rootLibrary;
-		} else {
-			_library = currentMirrorSystem().findLibrary(new Symbol(libraryName));
-		}
-		_loadTypes();
-	}
+  LibraryReflection(String libraryName) {
+    if (libraryName.isEmpty) {
+      _library = currentMirrorSystem().isolate.rootLibrary;
+    } else {
+      _library = currentMirrorSystem().findLibrary(new Symbol(libraryName));
+    }
+    _loadTypes();
+  }
 
-	void _loadTypes() {
-		_types = new List<TypeReflection>();
-		_library.declarations.forEach( (k, v) {
-			if ( v is ClassMirror ) {
-				_types.add( new TypeReflection( v.reflectedType));
-			}
-		});
-	}
+  void _loadTypes() {
+    _types = new List<TypeReflection>();
+    _library.declarations.forEach((k, v) {
+      try {
+        if (v is ClassMirror) {
+          _types.add(new TypeReflection.fromMirror(v));
+        }
+      } catch (e) {
+		  throw "Error when creating TypeReflection for type " + v.toString() + ": " + e.toString();
+	  }
+    });
+  }
 
-	List<TypeReflection> get types => _types;
+  List<TypeReflection> get types => _types;
 
-	String get name => MirrorSystem.getName(_library.qualifiedName);
+  String get name => MirrorSystem.getName(_library.qualifiedName);
 }

--- a/lib/src/core/library_reflection.dart
+++ b/lib/src/core/library_reflection.dart
@@ -7,6 +7,11 @@ class LibraryReflection
 	LibraryMirror _library;
 	List<TypeReflection> _types;
 
+	LibraryReflection.fromSymbol(Symbol libraryName)
+	{
+		_library = currentMirrorSystem().findLibrary(libraryName);
+	}
+
 	LibraryReflection(String libraryName) {
 		if (libraryName.isEmpty) {
 			_library = currentMirrorSystem().isolate.rootLibrary;

--- a/lib/src/core/library_reflection.dart
+++ b/lib/src/core/library_reflection.dart
@@ -27,4 +27,5 @@ class LibraryReflection
 
 	List<TypeReflection> get types => _types;
 
+	String get name => MirrorSystem.getName(_library.qualifiedName);
 }

--- a/lib/src/core/library_reflection.dart
+++ b/lib/src/core/library_reflection.dart
@@ -10,6 +10,7 @@ class LibraryReflection
 	LibraryReflection.fromSymbol(Symbol libraryName)
 	{
 		_library = currentMirrorSystem().findLibrary(libraryName);
+		_loadTypes();
 	}
 
 	LibraryReflection(String libraryName) {

--- a/lib/src/core/type_reflection.dart
+++ b/lib/src/core/type_reflection.dart
@@ -28,6 +28,8 @@ class TypeReflection<T> extends AbstractReflection<TypeMirror> {
     _getArgumentsFromMirror();
   }
 
+  get library => new LibraryReflection.fromSymbol((_mirror as ClassMirror).owner.simpleName);
+
   _getArgumentsFromMirror() {
     _arguments = new List.from(_mirror.typeArguments.map((m) {
       if (m.reflectedType == dynamic)

--- a/lib/src/core/type_reflection.dart
+++ b/lib/src/core/type_reflection.dart
@@ -36,6 +36,8 @@ class TypeReflection<T> extends AbstractReflection<TypeMirror> {
     }));
   }
 
+  TypeReflection get mixin => new TypeReflection((_mirror as ClassMirror).mixin.reflectedType);
+
   Type get rawType => _mirror.reflectedType;
 
   bool get isEnum => _mirror is ClassMirror ? (_mirror as ClassMirror).isEnum : false;

--- a/lib/src/core/type_reflection.dart
+++ b/lib/src/core/type_reflection.dart
@@ -11,10 +11,14 @@ class TypeReflection<T> extends AbstractReflection<TypeMirror> {
   List<GenericArgumentReflection> _genericArguments;
 
   TypeReflection(Type type, [List<Type> arguments]) : super(reflectType(type)) {
-    if (arguments != null) _arguments = new List.from(arguments.map((arg) => new TypeReflection(arg)));
-    else
-    {
-      _getArgumentsFromMirror( );
+    if (arguments != null) {
+      _getGenericArgumentsFromMirror();
+      for (var i = 0; i < _genericArguments.length; i++) {
+        if (arguments.length > i) _genericArguments[i].value = new TypeReflection(arguments[i]);
+      }
+      _arguments = new List.from(arguments.map((arg) => new TypeReflection(arg)));
+    } else {
+      _getArgumentsFromMirror();
       _getGenericArgumentsFromMirror();
     }
   }
@@ -46,15 +50,15 @@ class TypeReflection<T> extends AbstractReflection<TypeMirror> {
 
   _getGenericArgumentsFromMirror() {
     _genericArguments = new List<GenericArgumentReflection>();
-    for (var i = 0; i < _mirror.typeVariables.length; i++)
-    {
+    for (var i = 0; i < _mirror.typeVariables.length; i++) {
       var genericArgumentReflection = new GenericArgumentReflection()
         ..name = MirrorSystem.getName(_mirror.typeVariables[i].simpleName);
-      if ( _mirror.typeArguments.length > i )
-        genericArgumentReflection.value = new TypeReflection.fromMirror(_mirror.typeArguments[i]);
+      if (_mirror.typeArguments.length > i) genericArgumentReflection.value =
+          new TypeReflection.fromMirror(_mirror.typeArguments[i]);
       _genericArguments.add(genericArgumentReflection);
     }
   }
+
   TypeReflection _getTypeReflectionForArgument(TypeMirror m) {
     if (m.reflectedType == dynamic) return dynamicReflection;
     return new TypeReflection.fromMirror(m);

--- a/test/reflective.dart
+++ b/test/reflective.dart
@@ -11,16 +11,16 @@ main() {
   group('Reflection', () {
     test('Variable generic arguments', () {
       TypeReflection<Map<String, Project>> reflection = new TypeReflection(Map, [String, Project]);
-      expect(reflection.arguments.length, 2);
-      expect(reflection.arguments[0], new TypeReflection(String));
-      expect(reflection.arguments[1], new TypeReflection(Project));
+      expect(reflection.genericArguments.length, 2);
+      expect(reflection.genericArguments[0].value, new TypeReflection(String));
+      expect(reflection.genericArguments[1].value, new TypeReflection(Project));
     });
 
     test('Dynamic generic arguments', () {
       TypeReflection<Map> reflection = new TypeReflection.fromInstance({});
-      expect(reflection.arguments.length, 2);
-      expect(reflection.arguments[0], dynamicReflection);
-      expect(reflection.arguments[1], dynamicReflection);
+      expect(reflection.genericArguments.length, 2);
+      expect(reflection.genericArguments[0].value, dynamicReflection);
+      expect(reflection.genericArguments[1].value, dynamicReflection);
     });
 
     test('Transitive fields', () {

--- a/test/reflective.dart
+++ b/test/reflective.dart
@@ -102,6 +102,12 @@ main() {
       expect(mixinType.superclass.mixin.rawType, AMixin);
     });
 
+    test('Get library', () {
+      var typeReflection = type(TestType1);
+      expect(typeReflection.library.name, 'reflective.test_library');
+
+    });
+
     test('Reuse of reflections', () {
       // TODO
     });

--- a/test/reflective.dart
+++ b/test/reflective.dart
@@ -116,6 +116,11 @@ main() {
       expect(libraryReflection.types.any( (x) => x.rawType == TestBaseType ), true);
 
     });
+
+    test('Name', () {
+      var libraryReflection = new LibraryReflection('reflective.test_library');
+      expect(libraryReflection.name, 'reflective.test_library');
+    });
   });
 
   group('Conversion', () {

--- a/test/reflective.dart
+++ b/test/reflective.dart
@@ -113,6 +113,18 @@ main() {
       expect(typeReflection.isGeneric, true);
     });
 
+    test( "Generic properties", ( )
+    {
+      var mirror = reflectClass(GenericTypeWithAProperty);
+      var typeReflection = new TypeReflection.fromMirror(mirror.originalDeclaration);
+      var field = typeReflection.fields["property"];
+      expect(field.isGeneric, true);
+
+      var otherTypeReflection = type(BaseClass);
+      field = otherTypeReflection.fields["id"];
+      expect(field.isGeneric, false);
+    } );
+
     test('Non generic type', (){
       var typeReflection = type(Role);
       expect(typeReflection.isGeneric, false);
@@ -299,4 +311,9 @@ class AMixin
 
 class GenericType<T>
 {
+}
+
+class GenericTypeWithAProperty<T>
+{
+  T property;
 }

--- a/test/reflective.dart
+++ b/test/reflective.dart
@@ -97,6 +97,11 @@ main() {
       expect(departmentType.superclass.rawType, Object);
     });
 
+    test('With mixins', () {
+      var mixinType = type(ClassWithMixin);
+      expect(mixinType.superclass.mixin.rawType, AMixin);
+    });
+
     test('Reuse of reflections', () {
       // TODO
     });
@@ -240,4 +245,14 @@ abstract class AbstractBaseClass {
 class OtherSubclass extends AbstractBaseClass
 {
 
+}
+
+class ClassWithMixin extends AbstractBaseClass with AMixin
+{
+
+}
+
+class AMixin
+{
+  int mixinProperty;
 }

--- a/test/reflective.dart
+++ b/test/reflective.dart
@@ -4,6 +4,7 @@ import 'package:test/test.dart';
 import 'package:reflective/reflective.dart';
 import 'package:collection/equality.dart';
 import 'test_library.dart';
+import 'dart:mirrors';
 
 
 main() {
@@ -105,8 +106,36 @@ main() {
     test('Get library', () {
       var typeReflection = type(TestType1);
       expect(typeReflection.library.name, 'reflective.test_library');
-
     });
+
+    test('Generic types', () {
+      var typeReflection = type(GenericType);
+      expect(typeReflection.isGeneric, true);
+    });
+
+    test('Non generic type', (){
+      var typeReflection = type(Role);
+      expect(typeReflection.isGeneric, false);
+    });
+
+    test('Generic declaration', (){
+      ClassMirror typeMirror = reflectClass(GenericType);
+      var typeReflection = new TypeReflection.fromMirror(typeMirror.originalDeclaration);
+      expect(typeReflection.genericArguments.length, 1);
+      expect(typeReflection.genericArguments[0].name, "T");
+      expect(typeReflection.genericArguments[0].value, isNull);
+    });
+
+    test( "Instance of generic declaration", ( )
+    {
+      var instance = new GenericType<int>();
+      var typeReflection = new TypeReflection.fromInstance(instance);
+      expect(typeReflection.genericArguments.length, 1);
+      expect(typeReflection.genericArguments[0].name, "T");
+      expect(typeReflection.genericArguments[0].value, new TypeReflection(int));
+    } );
+
+
 
     test('Reuse of reflections', () {
       // TODO
@@ -266,4 +295,8 @@ class ClassWithMixin extends AbstractBaseClass with AMixin
 class AMixin
 {
   int mixinProperty;
+}
+
+class GenericType<T>
+{
 }


### PR DESCRIPTION
Hi Stijn,

Got another pull request for you here.  I hope you don't mind us contributing here, and making some breaking changes... :)

We're using your library for a few things, one of which is a dart to c# converter, and for that, we needed more information about generic arguments to types.  So I've added a "genericArguments" property and deprecated the existing "arguments" property.  The reason I did that is because I needed information about the names of the generic arguments, as well as their types.

Let me know if you think there is a better way to do what I've added here, and let me know if you have any questions about this pull request, or suggestions for refactoring :)

Cheers,

Matthew
